### PR TITLE
Make `eldoc-cmake-enable` interactive

### DIFF
--- a/eldoc-cmake.el
+++ b/eldoc-cmake.el
@@ -2,7 +2,7 @@
 ;;
 ;; Author: Kirill Ignatiev
 ;; URL: https://github.com/ikirill/eldoc-cmake
-;; Version: 0
+;; Version: 0.1
 ;; Package-Requires: ((emacs "25.1"))
 ;;
 ;;; Commentary:
@@ -23,6 +23,7 @@
 ;;;###autoload
 (defun eldoc-cmake-enable ()
   "Enable eldoc support for a CMake file."
+  (interactive)
   (setq-local eldoc-documentation-function
               #'eldoc-cmake--function)
   (unless eldoc-mode (eldoc-mode)))


### PR DESCRIPTION
This way, it could be called interactively with `M-x eldoc-cmake-enable`, not just by calling it from Elisp or by hooking it to a major mode.